### PR TITLE
Add upload UI with progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Self-hosted Dropbox-style app for LAN file sharing.
 
+Features include a mobile‑first interface with drag‑and‑drop uploads. Multiple
+files can be uploaded at once and each upload shows a progress bar. When an
+upload finishes the browser will display a notification if permissions allow.
+
 ## Quick Start
 ```bash
 git clone <repo>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import FileCard from '../components/FileCard'
+import Upload from '../components/Upload'
 
 const fetchFiles = async () => {
   const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/files/`)
@@ -13,10 +14,13 @@ const fetchFiles = async () => {
 export default function Home() {
   const { data } = useQuery({ queryKey: ['files'], queryFn: fetchFiles })
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      {data?.map((f: any) => (
-        <FileCard key={f.id} file={f} />
-      ))}
+    <div className="flex flex-col gap-4">
+      <Upload />
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {data?.map((f: any) => (
+          <FileCard key={f.id} file={f} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,9 +1,14 @@
 'use client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 const client = new QueryClient()
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {})
+    }
+  }, [])
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>
 }

--- a/frontend/components/Upload.tsx
+++ b/frontend/components/Upload.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useDropzone } from 'react-dropzone'
+import axios from 'axios'
+import { useQueryClient } from '@tanstack/react-query'
+
+interface Item {
+  id: string
+  file: File
+  progress: number
+  done: boolean
+}
+
+export default function Upload() {
+  const [items, setItems] = useState<Item[]>([])
+  const client = useQueryClient()
+
+  useEffect(() => {
+    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      Notification.requestPermission()
+    }
+  }, [])
+
+  const upload = (item: Item) => {
+    const data = new FormData()
+    data.append('file', item.file)
+    axios
+      .post(`${process.env.NEXT_PUBLIC_API_URL}/api/files/`, data, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+        onUploadProgress: (e) => {
+          const pct = e.total ? (e.loaded / e.total) * 100 : 0
+          setItems((list) =>
+            list.map((it) => (it.id === item.id ? { ...it, progress: pct } : it))
+          )
+        },
+      })
+      .then(() => {
+        setItems((list) =>
+          list.map((it) => (it.id === item.id ? { ...it, progress: 100, done: true } : it))
+        )
+        client.invalidateQueries({ queryKey: ['files'] })
+        if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+          new Notification(`${item.file.name} uploaded`)
+        }
+      })
+  }
+
+  const onDrop = useCallback((files: File[]) => {
+    const newItems = files.map((f) => ({ id: crypto.randomUUID(), file: f, progress: 0, done: false }))
+    setItems((prev) => [...prev, ...newItems])
+    newItems.forEach(upload)
+  }, [])
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, multiple: true })
+
+  return (
+    <div>
+      <div
+        {...getRootProps()}
+        className="p-4 mb-4 text-center border-2 border-dashed rounded-md cursor-pointer bg-white"
+      >
+        <input {...getInputProps()} />
+        {isDragActive ? <p>Drop the files here ...</p> : <p>Drag & drop or click to upload</p>}
+      </div>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div key={item.id}>
+            <div className="text-sm">{item.file.name}</div>
+            <div className="w-full h-2 bg-gray-200 rounded">
+              <div
+                className="h-2 bg-blue-500 rounded"
+                style={{ width: `${item.progress}%` }}
+              ></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- describe new multi-file uploader with progress & notifications
- add service worker registration
- integrate uploader into files grid
- document upload features in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test -- -q` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c124159f08320bf6572f1ad725fbc