### PR TITLE
Minor cleanup for Python modules

### DIFF
--- a/backend/files/models.py
+++ b/backend/files/models.py
@@ -13,7 +13,6 @@ class ExternalStorage(FileSystemStorage):
         super().__init__(location='/mnt/localbox', *args, **kwargs)
 
     def get_available_name(self, name: str, max_length: int | None = None) -> str:
-        ext = Path(name).suffix
         original = Path(name).name
         return f"{uuid.uuid4()}_{original}"
 

--- a/backend/files/views.py
+++ b/backend/files/views.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from ratelimit.decorators import ratelimit
-from rest_framework import viewsets, filters, status
-from rest_framework.response import Response
+from rest_framework import viewsets, filters
 from rest_framework.parsers import MultiPartParser, FormParser
 
 from .models import File

--- a/backend/localbox/urls.py
+++ b/backend/localbox/urls.py
@@ -1,6 +1,7 @@
 """URL configuration for LocalBox."""
-from django.http import HttpResponse
 from __future__ import annotations
+
+from django.http import HttpResponse
 
 from django.contrib import admin
 from django.urls import path, include

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from django.urls import reverse
 from rest_framework.test import APIClient
-import pytest
 from files.models import File
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- resolve ruff warnings in backend modules
- reorder imports in urls
- remove unused imports in tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686c176553588320aadacd281a041511