### PR TITLE
Add database migrations and upload preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ upload finishes the browser will display a notification if permissions allow.
 git clone <repo>
 cd drop-box
 cp .env.example .env
+docker compose run web python manage.py migrate
 docker compose up --build
 ```
 Open `http://<HOST_IP>:3000` in your browser.

--- a/backend/files/__init__.py
+++ b/backend/files/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'files.apps.FilesConfig'

--- a/backend/files/apps.py
+++ b/backend/files/apps.py
@@ -1,12 +1,15 @@
-# files/apps.py
-import os
+from __future__ import annotations
+
+from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
+import os
+from pathlib import Path
 
+class FilesConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'files'
 
-def ready(self):
-    # Change to a Windows-friendly path for local dev
-    mount_point = 'C:\\localbox'  # You can set this to anywhere you want
-    if not os.path.exists(mount_point):
-        os.makedirs(mount_point, exist_ok=True)
-    if not os.access(mount_point, os.W_OK):
-        raise ImproperlyConfigured(f'Mount point {mount_point} not writable')
+    def ready(self) -> None:  # type: ignore[override]
+        mount = Path('/mnt/localbox')
+        if not mount.exists() or not os.access(mount, os.W_OK):
+            raise ImproperlyConfigured('Mount point /mnt/localbox not writable')

--- a/backend/files/migrations/0001_initial.py
+++ b/backend/files/migrations/0001_initial.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+import uuid
+import files.models
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='File',
+            fields=[
+                ('id', models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, serialize=False)),
+                ('uploaded_by', models.CharField(max_length=255, null=True, blank=True)),
+                ('file', models.FileField(storage=files.models.storage, upload_to='')),
+                ('uploaded_at', models.DateTimeField(auto_now_add=True)),
+                ('size', models.BigIntegerField()),
+            ],
+        ),
+    ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   web:
     build: ./backend
-    command: gunicorn localbox.wsgi:application --bind 0.0.0.0:8000
+    command: sh -c "python manage.py migrate && gunicorn localbox.wsgi:application --bind 0.0.0.0:8000"
     volumes:
       - /mnt/localbox:/mnt/localbox
     env_file: .env

--- a/frontend/components/Upload.tsx
+++ b/frontend/components/Upload.tsx
@@ -8,6 +8,7 @@ interface Item {
   file: File
   progress: number
   done: boolean
+  url?: string
 }
 
 export default function Upload() {
@@ -33,9 +34,13 @@ export default function Upload() {
           )
         },
       })
-      .then(() => {
+      .then((resp) => {
         setItems((list) =>
-          list.map((it) => (it.id === item.id ? { ...it, progress: 100, done: true } : it))
+          list.map((it) =>
+            it.id === item.id
+              ? { ...it, progress: 100, done: true, url: resp.data.download_url }
+              : it
+          )
         )
         client.invalidateQueries({ queryKey: ['files'] })
         if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
@@ -65,6 +70,9 @@ export default function Upload() {
         {items.map((item) => (
           <div key={item.id}>
             <div className="text-sm">{item.file.name}</div>
+            {item.url && item.file.type.startsWith('image') && (
+              <img src={item.url} alt={item.file.name} className="mb-2 max-h-32" />
+            )}
             <div className="w-full h-2 bg-gray-200 rounded">
               <div
                 className="h-2 bg-blue-500 rounded"


### PR DESCRIPTION
## Summary
- add migrations for the `files` app
- fix `FilesConfig` to check the mount path
- automatically run migrations at container startup
- mention the migrate step in README
- show uploaded image previews in the UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686c7ef4c6588320bfd8b03d3e48701f