### PR TITLE
make media directory configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ DJANGO_DEBUG=false
 DJANGO_ALLOWED_HOSTS=*
 CORS_ORIGIN=http://localhost:3000
 
+# Where uploaded files are stored
+DJANGO_MEDIA_ROOT=./media
+
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Open `http://<HOST_IP>:3000` in your browser.
 ## Configuration
 - Change mount point by editing `.env` (`DJANGO_MEDIA_ROOT`).
 - Change host IP via `NEXT_PUBLIC_API_URL` in `.env`.
-- Backup: `rsync -av /mnt/localbox /path/to/backup/drive`.
+- Backup: `rsync -av $DJANGO_MEDIA_ROOT /path/to/backup/drive`.
 
 ## Drive Check
-`tools/check_drive.sh` ensures `/mnt/localbox` is writable before Django starts.
+`tools/check_drive.sh` ensures the directory defined by `DJANGO_MEDIA_ROOT` (defaults to `./media`) is writable before Django starts.

--- a/backend/files/apps.py
+++ b/backend/files/apps.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings
 import os
 from pathlib import Path
 
@@ -10,6 +11,8 @@ class FilesConfig(AppConfig):
     name = 'files'
 
     def ready(self) -> None:  # type: ignore[override]
-        mount = Path('/mnt/localbox')
-        if not mount.exists() or not os.access(mount, os.W_OK):
-            raise ImproperlyConfigured('Mount point /mnt/localbox not writable')
+        mount = Path(settings.MEDIA_ROOT)
+        if not mount.exists():
+            mount.mkdir(parents=True, exist_ok=True)
+        if not os.access(mount, os.W_OK):
+            raise ImproperlyConfigured(f'Mount point {mount} not writable')

--- a/backend/files/models.py
+++ b/backend/files/models.py
@@ -4,13 +4,14 @@ import uuid
 from pathlib import Path
 from django.db import models
 from django.core.files.storage import FileSystemStorage
+from django.conf import settings
 
 
 class ExternalStorage(FileSystemStorage):
     """Storage on mounted drive with UUID filenames."""
 
     def __init__(self, *args: str, **kwargs: str) -> None:
-        super().__init__(location='/mnt/localbox', *args, **kwargs)
+        super().__init__(location=str(settings.MEDIA_ROOT), *args, **kwargs)
 
     def get_available_name(self, name: str, max_length: int | None = None) -> str:
         original = Path(name).name

--- a/backend/localbox/settings.py
+++ b/backend/localbox/settings.py
@@ -75,7 +75,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-MEDIA_ROOT = os.environ.get('DJANGO_MEDIA_ROOT', '/mnt/localbox')
+MEDIA_ROOT = Path(os.environ.get('DJANGO_MEDIA_ROOT', BASE_DIR / 'media'))
 MEDIA_URL = '/media/'
 
 REST_FRAMEWORK = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: ./backend
     command: sh -c "python manage.py migrate && gunicorn localbox.wsgi:application --bind 0.0.0.0:8000"
     volumes:
-      - /mnt/localbox:/mnt/localbox
+      - ./media:/app/media
     env_file: .env
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz" ]
@@ -17,7 +17,7 @@ services:
     command: npm run start
     env_file: .env
     volumes:
-      - /mnt/localbox:/mnt/localbox
+      - ./media:/app/media
     ports:
       - "3000:3000"
     healthcheck:

--- a/tools/check_drive.sh
+++ b/tools/check_drive.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Fail if /mnt/localbox not writable
-if [ ! -w /mnt/localbox ]; then
-  echo "/mnt/localbox not writable" >&2
+# Fail if MEDIA_ROOT not writable
+CHECK_PATH="${DJANGO_MEDIA_ROOT:-./media}"
+if [ ! -w "$CHECK_PATH" ]; then
+  echo "$CHECK_PATH not writable" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- allow setting MEDIA_ROOT from environment and default to `./media`
- update File storage and startup checks to use MEDIA_ROOT
- revise Docker and compose setup for new path
- document MEDIA_ROOT in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686c815d4acc832089a1f955d56682e6