### PR TITLE
Fix LAN media URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,5 @@ CORS_ORIGIN=http://localhost:3000
 DJANGO_MEDIA_ROOT=./media
 
 # Frontend
+# Use http://<HOST_IP>:8000 for LAN access
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ docker compose up --build
 ```
 Open `http://<HOST_IP>:3000` in your browser.
 
+When accessing from other devices on your LAN, set `NEXT_PUBLIC_API_URL` in
+`.env` to `http://<HOST_IP>:8000` so media links resolve correctly.
+
 ## Configuration
 - Change mount point by editing `.env` (`DJANGO_MEDIA_ROOT`).
-- Change host IP via `NEXT_PUBLIC_API_URL` in `.env`.
+- Change host IP via `NEXT_PUBLIC_API_URL` in `.env` (use `http://web:8000` when running in Docker).
+- Ensure port `8000` is exposed in `docker-compose.yml` for media URLs.
 - Backup: `rsync -av $DJANGO_MEDIA_ROOT /path/to/backup/drive`.
 
 ## Drive Check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ./media:/app/media
     env_file: .env
+    ports:
+      - "8000:8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz" ]
       interval: 30s


### PR DESCRIPTION
## Summary
- expose port 8000 so uploaded files are reachable on the LAN
- clarify LAN setup steps in README
- mention LAN usage in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686d2cd83c6c8320b6b20e400fdde233