### PR TITLE
Fix API URL default to prevent undefined path

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,7 +7,8 @@ import FileCard from '../components/FileCard'
 import Upload from '../components/Upload'
 
 const fetchFiles = async () => {
-  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/files/`)
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? ''
+  const { data } = await axios.get(`${baseUrl}/api/files/`)
   return data.results
 }
 

--- a/frontend/components/Upload.tsx
+++ b/frontend/components/Upload.tsx
@@ -24,8 +24,9 @@ export default function Upload() {
   const upload = (item: Item) => {
     const data = new FormData()
     data.append('file', item.file)
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? ''
     axios
-      .post(`${process.env.NEXT_PUBLIC_API_URL}/api/files/`, data, {
+      .post(`${baseUrl}/api/files/`, data, {
         headers: { 'Content-Type': 'multipart/form-data' },
         onUploadProgress: (e) => {
           const pct = e.total ? (e.loaded / e.total) * 100 : 0


### PR DESCRIPTION
## Summary
- ensure front-end uses empty string if `NEXT_PUBLIC_API_URL` is not set

## Testing
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent --maxWorkers=2` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ef7fc24832082c45ba37f5a5e87