### PR TITLE
Fix env var passing to Next.js build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
       retries: 3
     restart: unless-stopped
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
     command: npm run start
     env_file: .env
     volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,14 @@
 FROM node:20-alpine
 WORKDIR /app
+
+# Pass API URL at build time so Next can inline it
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+
 COPY package.json package-lock.json* ./
 RUN npm install
 COPY . .
+# Build with environment variables available
 RUN npm run build
+
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- propagate NEXT_PUBLIC_API_URL to the Next.js build
- expose the build arg via docker compose

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686d30f67e648320b8f110801284d0cf