### PR TITLE
Add auth-aware responsive navbar

### DIFF
--- a/frontend/app/auth.tsx
+++ b/frontend/app/auth.tsx
@@ -1,0 +1,62 @@
+'use client'
+import React, { createContext, useContext, useState } from 'react'
+import axios from 'axios'
+import { useRouter } from 'next/navigation'
+
+interface Auth {
+  token: string | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<Auth>({
+  token: null,
+  login: async () => {},
+  logout: async () => {},
+})
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(
+    typeof window === 'undefined' ? null : localStorage.getItem('token')
+  )
+  const router = useRouter()
+
+  const login = async (username: string, password: string) => {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? ''
+    const { data } = await axios.post(`${baseUrl}/auth/login/`, {
+      username,
+      password,
+    })
+    localStorage.setItem('token', data.token)
+    setToken(data.token)
+    router.push('/')
+  }
+
+  const logout = async () => {
+    if (token) {
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? ''
+      try {
+        await axios.post(
+          `${baseUrl}/auth/logout/`,
+          {},
+          { headers: { Authorization: `Token ${token}` } }
+        )
+      } catch {
+        // ignore
+      }
+    }
+    localStorage.removeItem('token')
+    setToken(null)
+    router.push('/login')
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import { Providers } from './providers'
 import React from 'react'
+import NavBar from '../components/NavBar'
 
 export const metadata = {
   title: 'LocalBox',
@@ -16,7 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body className="bg-gray-100">
         <Providers>
-          <div className="p-4 bg-white shadow">LocalBox</div>
+          <NavBar />
           <main className="p-4 max-w-screen-sm mx-auto">{children}</main>
         </Providers>
       </body>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+import React, { useState, useEffect } from 'react'
+import { useAuth } from '../auth'
+import { useRouter } from 'next/navigation'
+
+export default function LoginPage() {
+  const { login, token } = useAuth()
+  const router = useRouter()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  useEffect(() => {
+    if (token) {
+      router.push('/')
+    }
+  }, [token, router])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    login(username, password)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="max-w-xs mx-auto mt-10 space-y-4"
+    >
+      <div>
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full border p-2 rounded"
+        />
+      </div>
+      <div>
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border p-2 rounded"
+        />
+      </div>
+      <button
+        type="submit"
+        className="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600"
+      >
+        Login
+      </button>
+    </form>
+  )
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import FileCard from '../components/FileCard'
 import Upload from '../components/Upload'
+import { useAuth } from './auth'
+import { useRouter } from 'next/navigation'
 
 const fetchFiles = async () => {
   const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? ''
@@ -13,6 +15,13 @@ const fetchFiles = async () => {
 }
 
 export default function Home() {
+  const { token } = useAuth()
+  const router = useRouter()
+  useEffect(() => {
+    if (!token) {
+      router.push('/login')
+    }
+  }, [token, router])
   const { data } = useQuery({ queryKey: ['files'], queryFn: fetchFiles })
   return (
     <div className="flex flex-col gap-4">

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React, { useEffect } from 'react'
+import { AuthProvider } from './auth'
 
 const client = new QueryClient()
 
@@ -10,5 +11,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       navigator.serviceWorker.register('/sw.js').catch(() => {})
     }
   }, [])
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={client}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  )
 }

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -1,0 +1,20 @@
+'use client'
+import React from 'react'
+import { useAuth } from '../app/auth'
+
+export default function NavBar() {
+  const { token, logout } = useAuth()
+  return (
+    <nav className="p-4 bg-white shadow flex justify-between items-center">
+      <span className="font-semibold text-lg truncate">LocalBox</span>
+      {token && (
+        <button
+          onClick={logout}
+          className="text-sm text-blue-500 hover:text-blue-700"
+        >
+          Logout
+        </button>
+      )}
+    </nav>
+  )
+}

--- a/frontend/components/Upload.tsx
+++ b/frontend/components/Upload.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import axios from 'axios'
@@ -25,9 +26,14 @@ export default function Upload() {
     const data = new FormData()
     data.append('file', item.file)
     const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? ''
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('token') : null
     axios
       .post(`${baseUrl}/api/files/`, data, {
-        headers: { 'Content-Type': 'multipart/form-data' },
+        headers: {
+          'Content-Type': 'multipart/form-data',
+          ...(token ? { Authorization: `Token ${token}` } : {}),
+        },
         onUploadProgress: (e) => {
           const pct = e.total ? (e.loaded / e.total) * 100 : 0
           setItems((list) =>


### PR DESCRIPTION
## Summary
- add Auth context and Login page
- add NavBar with logout
- wire AuthProvider into app providers
- require auth on homepage
- include auth token on uploads

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f17aad9908320a9e79eea532bb27f